### PR TITLE
Fix the memory leak when searching for ''

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "should": "~3.3.1",
     "expect": "~0.1.1",
     "supertest": "~0.12.0",
-    "memwatch": "~0.2.2"
+    "memwatch": "~0.2.2",
+    "require-env": "0.0.4"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Found a couple issues while digging through this:
- errors weren't being handled properly (they were getting swallowed and `callback` was never being called, so requests would just hang)
- if no search query (`q`) was provided, `dbQuery` would never get set to its default value (`yosemite`), which resulted in `SELECT * FROM cpad_2013b_superunits_ids_4326 WHERE LOWER( unit_name ) LIKE \'%%\''` (this returns _all_ rows, and since you're querying for `*`, it grabs the _rather large_ geometry columns in the process; it's not clear to me if `data.limit` would have been set)

/cc @standardpixel 
