### PR TITLE
Make Instagram 404s collapse

### DIFF
--- a/sass/_block-instagram-strip.scss
+++ b/sass/_block-instagram-strip.scss
@@ -12,6 +12,29 @@
     box-sizing:border-box;
     font-size: 0 ;
     overflow-scrolling: touch !important;
+
+    > div {
+      height:119px;
+      width:119px;
+      box-sizing:border-box;
+      display:inline-block;
+      position:relative;
+
+      .attribution {
+        display:block;
+        position:absolute;
+        bottom:5px;left:5px;
+        color:transparent;
+        height: 13px;
+        width: 13px;
+        background-image:url('responsive2/instagram-logo.svg');
+        background-repeat:no-repeat;
+      }
+
+      &:first-of-type {
+        margin-left:0px;
+      }
+    }
   }
 
   button {

--- a/sass/_block-instagram-strip.scss
+++ b/sass/_block-instagram-strip.scss
@@ -12,37 +12,6 @@
     box-sizing:border-box;
     font-size: 0 ;
     overflow-scrolling: touch !important;
-
-    > div {
-      height:119px;
-      width:119px;
-      box-sizing:border-box;
-      display:inline-block;
-      position:relative;
-
-      background-size:cover;
-      display:block;
-      background-position: center center;
-
-      .attribution {
-        display:block;
-        position:absolute;
-        bottom:5px;left:5px;
-        cursor:pointer;
-        color:transparent;
-        height: 13px;
-        width: 13px;
-        background-image:url('responsive2/instagram-logo.svg');
-        background-repeat:no-repeat;
-        >div, >a {
-          display:none;
-        }
-      }
-
-      &:first-of-type {
-        margin-left:0px;
-      }
-    }
   }
 
   button {

--- a/views/partials/block-instagram-strip.handlebars
+++ b/views/partials/block-instagram-strip.handlebars
@@ -1,5 +1,5 @@
 <div class="block-instagram-strip what-scrollbars">
-  <div class="slide-container">
+  <div id="instagram-slide-container" class="slide-container">
   {{#each instagram.items}}
     {{>instagram-photo}}
   {{/each}}

--- a/views/partials/instagram-photo.handlebars
+++ b/views/partials/instagram-photo.handlebars
@@ -1,3 +1,3 @@
-<div class="instagram-photo" style="display: inline-block;">
+<div class="instagram-photo">
   <a href="{{link}}" title="{{title}} by {{username}} on Instagram"><img src="{{thumb}}" width="119" height="119" onerror="document.getElementById('instagram-slide-container').removeChild(this.parentNode.parentNode);" alt="{{title}}"><span class="attribution"></span></a>
 </div>

--- a/views/partials/instagram-photo.handlebars
+++ b/views/partials/instagram-photo.handlebars
@@ -1,5 +1,3 @@
-<a href="{{link}}">
-  <div onclick="location.href = '{{link}}'" class="instagram-photo" data-link="{{link}}" style="cursor:pointer;display:inline-block; background-image:url('{{thumb}}');background-size: 128px 128px;">
-    <a href="{{link}}" class="attribution">By {{username}} on Instagram</a>
-  </div>
-</a>
+<div class="instagram-photo" style="display: inline-block;">
+  <a href="{{link}}" title="{{title}} by {{username}} on Instagram"><img src="{{thumb}}" width="119" height="119" onerror="document.getElementById('instagram-slide-container').removeChild(this.parentNode.parentNode);" alt="{{title}}"><span class="attribution"></span></a>
+</div>


### PR DESCRIPTION
This uses `onerror` events (only present on `<img>` tags; background images fail silently) to remove nodes from the DOM when Instagram images 404 (eliminating unsightly grey gaps that form).

I'm currently experiencing sass errors, so I think there's a `dist/` version of `_block-instagram-strip.scss` that's missing:

```
unknown command: sass --watch ./sass:./public/style
```

/cc @standardpixel 
