### PR TITLE
harvester makefile, explicitly define SHELL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 PATH := node_modules/.bin:$(PATH)
 
+SHELL=/bin/bash
+
 define EXPAND_EXPORTS
 export $(word 1, $(subst =, , $(1))) := $(word 2, $(subst =, , $(1)))
 endef


### PR DESCRIPTION
Explicitly defining the `SHELL` variable in the harvester Makefile, improves cross-platform behavior.

On some Linux (e.g. Ubuntu) `/bin/sh` is not Bash but instead Dash. Attempting to run migrations, results in "bad substitution" messages instead of the SQL migrations being run.
